### PR TITLE
Allow passing options to uglify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,14 @@ import uglify from 'uglify-js';
 export default function (options = {}) {
 	return {
 		transformBundle(code) {
-			let uglifyOptions = {
-				fromString: true
-			};
+			options.fromString = true;
 
 			// trigger sourcemap generation
 			if (options.sourceMap !== false) {
-				uglifyOptions.outSourceMap = 'x';
+				options.outSourceMap = 'x';
 			}
 
-			let result = uglify.minify(code, uglifyOptions);
+			let result = uglify.minify(code, options);
 
 			// Strip sourcemaps comment and extra \n
 			if (result.map) {


### PR DESCRIPTION
I'm updating the build process for one of my libraries to use this plugin and the new `banner` option in Rollup. However the copyright that I am inserting is getting stripped out https://github.com/patrickarlt/esri-leaflet/blob/update-build-process/rollup.conf.js#L7-L11. By default uglify only preserves comments if you are using the CLI and strips all comments if you use the API.

Normally you would just set the `comments` option on `uglify.minify` but you cant pass options to the plugin right now. With this PR you could do this:

```js
import { rollup } from 'rollup';
import uglify from 'rollup-plugin-uglify';

rollup({
    entry: 'main.js',
    plugins: [
        uglify({
          output: { comments: 'all' }
        })
    ]
});
```