### PR TITLE
Allow passing minifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ rollup({
 
 ## Warning
 [UglifyJS](https://github.com/mishoo/UglifyJS2), which this plugin is based on, does not support the ES2015 module syntax. Thus using this plugin with Rollup's default bundle format (`'es6'`) will not work and error out.
+To work around this you can tell `rollup-plugin-uglify` to use the UglifyJS [harmony branch](https://github.com/mishoo/UglifyJS2/tree/harmony) by passing its `minify` function to minify your code.
+```js
+import { rollup } from 'rollup';
+import uglify from 'rollup-plugin-uglify';
+import { minify } from 'uglify-js';
+
+rollup({
+	entry: 'main.js',
+	plugins: [
+		uglify({}, minify)
+	]
+});
+```
 
 # License
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import uglify from 'uglify-js';
 
-export default function (options = {}) {
+export default function (options = {}, minifier = uglify.minify) {
     return {
         transformBundle(code) {
             options.fromString = true;
@@ -12,7 +12,7 @@ export default function (options = {}) {
                 options.outSourceMap = 'x';
             }
 
-            const result = uglify.minify(code, options);
+            const result = minifier(code, options);
 
             // Strip sourcemaps comment and extra \n
             if (result.map) {

--- a/test/fixtures/plain-file.js
+++ b/test/fixtures/plain-file.js
@@ -1,0 +1,2 @@
+const foo = 'bar';
+console.log(foo);

--- a/test/test.js
+++ b/test/test.js
@@ -51,3 +51,31 @@ test('should minify with sourcemaps', t => {
         t.ok(result.map.mappings, 'source map has mappings');
     });
 });
+
+test('should allow passing minifier', t => {
+    const expectedCode = readFile('fixtures/plain-file.js', 'utf-8');
+    const testOptions = {
+        foo: 'bar'
+    };
+
+    return rollup({
+        entry: 'fixtures/plain-file.js',
+        plugins: [ uglify(testOptions, (code, options) => {
+            t.ok(code, 'has unminified code');
+            t.is(`${code}\n`,
+                expectedCode,
+                'expected file content is passed to minifier');
+            t.ok(options, 'has minifier options');
+            t.is(options.foo, 'bar', 'minifier gets custom options');
+
+            return { code };
+        })]
+    }).then(bundle => {
+        const result = bundle.generate();
+
+        t.ok(result.code, 'result has return code');
+        t.is(`${result.code}\n`,
+            expectedCode,
+            'result code has expected content');
+    });
+});


### PR DESCRIPTION
This allows the plugin to be used with https://github.com/mishoo/UglifyJS2/tree/harmony to minify ES2015 code without converting it to ES5 with babel first.