### PR TITLE
Preserve .js filename extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Rollup plugin to minify generated bundle",
   "main": "dist/rollup-plugin-uglify.js",
+  "module": "dist/rollup-plugin-uglify.es.js",
   "jsnext:main": "dist/rollup-plugin-uglify.es.js",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Rollup plugin to minify generated bundle",
   "main": "dist/rollup-plugin-uglify.js",
-  "jsnext:main": "dist/rollup-plugin-uglify.mjs",
+  "jsnext:main": "dist/rollup-plugin-uglify.es.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Follow the convention of official plugins, see https://github.com/rollup/rollup-plugin-babel/blob/master/rollup.config.js