### PR TITLE
add code frame for debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ export default function uglify(options = {}, minifier = minify) {
 			try {
 				var result = minifier(code, options);
 			} catch (error) {
-				console.log(frame(code, error.line, error.col, frameOptions));
-				console.log('Reason: ' + error.message);
+				console.error(frame(code, error.line, error.col, frameOptions));
+				console.error('Reason: ' + error.message);
 				// Throw again so rollup can catch and output as normal
 				throw error;
 			}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
 import { minify } from 'uglify-js';
+import frame from 'babel-code-frame';
+
+const frameOptionsDefaults = {
+	highlightCode: true,
+	linesAbove: 2,
+	linesBelow: 3,
+	forceColor: false
+};
 
 export default function uglify(options = {}, minifier = minify) {
+	let frameOptions = options.codeFrame ? Object.assign({}, frameOptionsDefaults, options.codeFrame) : frameOptionsDefaults;
+
 	return {
 		name: 'uglify',
 
@@ -14,7 +24,14 @@ export default function uglify(options = {}, minifier = minify) {
 				options.outSourceMap = 'x';
 			}
 
-			const result = minifier(code, options);
+			try {
+				var result = minifier(code, options);
+			} catch (error) {
+				console.log(frame(code, error.line, error.col, frameOptions));
+				console.log('Reason: ' + error.message);
+				// Throw again so rollup can catch and output as normal
+				throw error;
+			}
 
 			// Strip sourcemaps comment and extra \n
 			if (result.map) {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/TrySound/rollup-plugin-uglify#readme",
   "dependencies": {
-    "babel-code-frame": "^6.20.0",
-    "uglify-js": "^2.6.1"
+    "babel-code-frame": "^6.22.0",
+    "uglify-js": "^2.7.5"
   },
   "devDependencies": {
     "buble": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/TrySound/rollup-plugin-uglify#readme",
   "dependencies": {
+    "babel-code-frame": "^6.20.0",
     "uglify-js": "^2.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "uglify-js": "^2.6.1"
   },
   "devDependencies": {
-    "buble": "^0.10.6",
-    "mocha": "^2.5.3",
-    "rollup": "^0.31.1",
-    "rollup-plugin-buble": "^0.10.0"
+    "buble": "^0.15.2",
+    "mocha": "^3.2.0",
+    "rollup": "^0.41.4",
+    "rollup-plugin-buble": "^0.15.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ export default {
 			dest: pkg['main']
 		},
 		{
-			format: 'es6',
+			format: 'es',
 			dest: pkg['jsnext:main']
 		}
 	]

--- a/test/test.js
+++ b/test/test.js
@@ -10,36 +10,36 @@ describe('rollup-plugin-uglify', () => {
 	it('should minify', () => {
 		return rollup({
 			entry: 'fixtures/unminified.js',
-			plugins: [ uglify() ]
+			plugins: [uglify()]
 		}).then(bundle => {
 			const unminified = readFile('fixtures/unminified.js', 'utf-8');
 			const result = bundle.generate({
 				format: 'cjs'
 			});
-			assert.equal(result.code, minify(unminified, { fromString: true }).code);
+			assert.equal(result.code.trim(), minify(unminified, { fromString: true }).code);
 		});
 	});
 
 	it('should minify via uglify options', () => {
 		return rollup({
 			entry: 'fixtures/empty.js',
-			plugins: [ uglify({
+			plugins: [uglify({
 				output: { comments: 'all' }
-			}) ]
+			})]
 		}).then(bundle => {
 			const result = bundle.generate({
 				banner: '/* package name */',
 				format: 'cjs'
 			});
 
-			assert.equal(result.code, '/* package name */\n"use strict";');
+			assert.equal(result.code.trim(), '/* package name */\n"use strict";');
 		});
 	});
 
 	it('should minify with sourcemaps', () => {
 		return rollup({
 			entry: 'fixtures/sourcemap.js',
-			plugins: [ uglify() ]
+			plugins: [uglify()]
 		}).then(bundle => {
 			const result = bundle.generate({
 				format: 'cjs',
@@ -63,7 +63,7 @@ describe('rollup-plugin-uglify', () => {
 
 		return rollup({
 			entry: 'fixtures/plain-file.js',
-			plugins: [ uglify(testOptions, (code, options) => {
+			plugins: [uglify(testOptions, (code, options) => {
 				assert.ok(code, 'has unminified code');
 				assert.equal(code, expectedCode.trim(), 'expected file content is passed to minifier');
 				assert.ok(options, 'has minifier options');
@@ -75,7 +75,7 @@ describe('rollup-plugin-uglify', () => {
 			const result = bundle.generate();
 
 			assert.ok(result.code, 'result has return code');
-			assert.equal(result.code, expectedCode.trim(), 'result code has expected content');
+			assert.equal(result.code.trim(), expectedCode.trim(), 'result code has expected content');
 		});
 	});
 });


### PR DESCRIPTION
i'm porting a big project to rollup and es6.

noticed that any error raised by uglify gets striped of the line/col number by rollup try/catch. i was trying to debug a rollup bug (outputs es6 code in a specific case with cjs or iife format) that uglify doesnt like. to find the code actually raising error in uglify i needed to run it separate from rollup. 

so i made this PR which logs the actual line/col number and uses babel-code-frame to show a nice snippet in the console.

hope you consider merging this.   


![uglify](https://cloud.githubusercontent.com/assets/314190/22030538/ca998b0c-dcd5-11e6-8963-96702c9f4de5.png)
