### PR TITLE
Update instructions for use of ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ uglify(options, minifier)
 `minifier` – default: `require('uglify-js').minify`, type: `function`. Module to use as a minifier. You can use other versions (or forks) of UglifyJS instead default one.
 
 ## Warning
+
 [UglifyJS](https://github.com/mishoo/UglifyJS2), which this plugin is based on, does not support the ES2015 module syntax. Thus using this plugin with Rollup's default bundle format (`'es6'`) will not work and error out.
 To work around this you can tell `rollup-plugin-uglify` to use the UglifyJS [harmony branch](https://github.com/mishoo/UglifyJS2/tree/harmony) by passing its `minify` function to minify your code.
 ```js
@@ -50,6 +51,10 @@ rollup({
 	]
 });
 ```
+
+To install the experimental version of UglifyJS:
+
+    npm i -D uglify-js-harmony
 
 ## Examples
 


### PR DESCRIPTION
The current README instructions for using ES6/Harmony/ES2015 were not easy to follow, and I found I did not need to pass in the `minify` option. Hence the pull.

Environment

    node -v && npm -v
    v6.3.1
    3.10.3
