### PR TITLE
Bump dependencies. Support UglifyJS 3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,9 @@ export default function uglify(options = {}, minifier = minify) {
 		name: 'uglify',
 
 		transformBundle(code) {
-			options.fromString = true;
-			delete options.inSourceMap;
-			delete options.outSourceMap;
-
 			// trigger sourcemap generation
 			if (options.sourceMap !== false) {
-				options.outSourceMap = 'x';
+				options.sourceMap = true;
 			}
 
 			const result = minifier(code, options);

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "homepage": "https://github.com/TrySound/rollup-plugin-uglify#readme",
   "dependencies": {
-    "uglify-js": "^2.6.1"
+    "uglify-js": "^3.0.1"
   },
   "devDependencies": {
-    "buble": "^0.10.6",
-    "mocha": "^2.5.3",
-    "rollup": "^0.31.1",
-    "rollup-plugin-buble": "^0.10.0"
+    "buble": "^0.15.2",
+    "mocha": "^3.3.0",
+    "rollup": "^0.41.6",
+    "rollup-plugin-buble": "^0.15.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,8 +11,8 @@ export default {
 			dest: pkg['main']
 		},
 		{
-			format: 'es6',
-			dest: pkg['jsnext:main']
+			format: 'es',
+			dest: pkg.module
 		}
 	]
 };

--- a/test/fixtures/plain-file.js
+++ b/test/fixtures/plain-file.js
@@ -1,2 +1,4 @@
+'use strict';
+
 const foo = 'bar';
 console.log(foo);

--- a/test/fixtures/unminified.js
+++ b/test/fixtures/unminified.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var a = 5;
 
 if (a < 3) {

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,8 @@ const uglify = require('../');
 
 process.chdir('test');
 
+const trim = str => str.replace(/\s+$/g, '');
+
 describe('rollup-plugin-uglify', () => {
 	it('should minify', () => {
 		return rollup({
@@ -16,7 +18,8 @@ describe('rollup-plugin-uglify', () => {
 			const result = bundle.generate({
 				format: 'cjs'
 			});
-			assert.equal(result.code, minify(unminified, { fromString: true }).code);
+
+			assert.equal(trim(result.code), trim('"use strict";var a=5;a<3&&console.log(4)'));
 		});
 	});
 
@@ -32,7 +35,7 @@ describe('rollup-plugin-uglify', () => {
 				format: 'cjs'
 			});
 
-			assert.equal(result.code, '/* package name */\n"use strict";');
+			assert.equal(trim(result.code), trim('/* package name */\n"use strict"'));
 		});
 	});
 
@@ -65,17 +68,19 @@ describe('rollup-plugin-uglify', () => {
 			entry: 'fixtures/plain-file.js',
 			plugins: [ uglify(testOptions, (code, options) => {
 				assert.ok(code, 'has unminified code');
-				assert.equal(code, expectedCode.trim(), 'expected file content is passed to minifier');
+				assert.equal(trim(code), trim(expectedCode), 'expected file content is passed to minifier');
 				assert.ok(options, 'has minifier options');
 				assert.equal(options.foo, 'bar', 'minifier gets custom options');
 
 				return { code };
 			})]
 		}).then(bundle => {
-			const result = bundle.generate();
+			const result = bundle.generate({
+        format: 'cjs'
+			});
 
 			assert.ok(result.code, 'result has return code');
-			assert.equal(result.code, expectedCode.trim(), 'result code has expected content');
+			assert.equal(trim(result.code), trim(expectedCode), 'result code has expected content');
 		});
 	});
 });


### PR DESCRIPTION
This superseds https://github.com/TrySound/rollup-plugin-uglify/pull/20. Would be good to merge these often to prevent duplicate work.