### PR TITLE
Fix docs with uglify-es

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { minify } from 'uglify-es';
 rollup({
     entry: 'main.js',
     plugins: [
-        uglify({}, minify)
+        uglify({}, minify.minify)
     ]
 });
 ```


### PR DESCRIPTION
Since `require('uglify-js').minify` is the default, we also need `.minify` when using uglify-es.