### PR TITLE
Use uglify-es instead of uglify-js to bundle ES6+ code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { codeFrameColumns } = require("@babel/code-frame");
-const { minify } = require("uglify-js");
+const { minify } = require("uglify-es");
 
 function uglify(userOptions, minifier = minify) {
   const options = Object.assign({ sourceMap: true }, userOptions);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/code-frame": "^7.0.0-beta.47",
-    "uglify-js": "^3.3.25"
+    "uglify-es": "^3.3.9"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.47",


### PR DESCRIPTION
As [emphasised by Google](https://developers.google.com/web/fundamentals/primers/modules), it's now possible to use the native ES modules in all major browsers and thus, support all of the new ES functionalities without transpiling --> huge size gain.