### PR TITLE
feat: add support for filter by chunk files names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,36 @@ Generates source maps and passes them to rollup. Defaults to `true`.
 
 Amount of workers to spawn. Defaults to the number of CPUs minus 1.
 
+`options.include: Array<string | RegExp> | string | RegExp`
+`options.exclude: Array<string | RegExp> | string | RegExp`
+
+Specifically include/exclude chunk files names (minimatch pattern, or array of minimatch patterns), By default all chunk files will be minify.
 
 ## Examples
+
+### include/exclude
+If you'd like that only some of the files will be minify, then you can filter by `include` and `exclude` to do this like so:
+
+```js
+// rollup.config.js
+import { uglify } from "rollup-plugin-uglify";
+
+export default {
+  input: "some.js",
+  output: [
+    { file: 'some.js' },
+    { file: 'some.min.js' },
+    { file: 'foo.min.js' },
+    { file: 'other.min.js' }
+  ],
+  plugins: [
+    uglify({
+      include: /^.+\.min\.js$/, 
+      exclude: ['foo.min.js', 'other*']
+    })
+  ]
+};
+```
 
 ### Comments
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
 const serialize = require("serialize-javascript");
+const { createFilter } = require('rollup-pluginutils');
 
 function uglify(userOptions = {}) {
   if (userOptions.sourceMap != null) {
     throw Error("sourceMap option is removed, use sourcemap instead");
   }
 
+  const filter = createFilter( userOptions.include, userOptions.exclude, { resolve: false } );
+
   const minifierOptions = serialize(
     Object.assign({}, userOptions, {
+      exclude: undefined,
+      include: undefined,
       sourceMap: userOptions.sourcemap !== false,
       sourcemap: undefined,
       numWorkers: undefined
@@ -24,7 +29,11 @@ function uglify(userOptions = {}) {
       });
     },
 
-    renderChunk(code) {
+    renderChunk(code, { fileName }) {
+      if(!filter(fileName)){
+        return null;
+      }
+
       return this.worker.transform(code, minifierOptions).catch(error => {
         const { message, line, col: column } = error;
         console.error(

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "jest-worker": "^24.0.0",
+    "rollup-pluginutils": "^2.8.1",
     "serialize-javascript": "^1.6.1",
     "uglify-js": "^3.4.9"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,4 @@
-const assert = require("assert");
 const { rollup } = require("rollup");
-const { readFileSync: readFile } = require("fs");
 const { uglify } = require("../");
 
 test("minify", async () => {
@@ -9,7 +7,7 @@ test("minify", async () => {
     plugins: [uglify()]
   });
   const result = await bundle.generate({ format: "cjs" });
-  const { code, map } = result.output[0]
+  const { code, map } = result.output[0];
   expect(code).toEqual(
     '"use strict";window.a=5,window.a<3&&console.log(4);\n'
   );
@@ -25,7 +23,7 @@ test("minify via uglify options", async () => {
     banner: "/* package name */",
     format: "cjs"
   });
-  const { code, map } = result.output[0]
+  const { code, map } = result.output[0];
   expect(code).toEqual('/* package name */\n"use strict";\n');
   expect(map).toBeFalsy();
 });
@@ -36,7 +34,7 @@ test("minify with sourcemaps", async () => {
     plugins: [uglify()]
   });
   const result = await bundle.generate({ format: "cjs", sourcemap: true });
-  const { code, map } = result.output[0]
+  const { code, map } = result.output[0];
   expect(map).toBeTruthy();
 });
 
@@ -103,4 +101,43 @@ test("allow to pass not string values to worker", async () => {
   expect(result.output[0].code).toEqual(
     '"use strict";window.a=5,window.a<3&&console.log(4);\n'
   );
+});
+
+test("include chunk file by string name", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [ uglify({ include: 'some.js' }) ]
+  });
+
+  const result = await bundle.generate({ format: "es", file: 'some.js' });
+  const { code, map } = result.output[0];
+  expect(code).toBe(`window.a=5,window.a<3&&console.log(4);\n`);
+  expect(map).toBeFalsy();
+});
+
+test("exclude chunk file pattern name by minimatch pattern", async () => {
+  const bundle = await rollup({
+    input: "test/fixtures/unminified.js",
+    plugins: [ uglify({ exclude: '*-cjs.js' }) ]
+  });
+  const result = await bundle.generate({ format: "cjs", entryFileNames: '[name]-[format].js' });
+  const { code, map } = result.output[0];
+
+  expect(code).toBe(`'use strict';\n\nwindow.a = 5;\n\nif (window.a < 3) {\n  console.log(4);\n}\n`);
+  expect(map).toBeFalsy();
+});
+
+test("include only one chunk file by regex", async () => {
+  const bundle = await rollup({
+    input: [ "test/fixtures/chunk-1.js", "test/fixtures/chunk-2.js" ],
+    plugins: [ uglify({ include: /.+-1\.\w+/ }) ]
+  });
+  const result = await bundle.generate({ format: "es" });
+  const chunk1 = result.output[0];
+  const chunk2 = result.output[1];
+
+  expect(chunk1.code).toBe(`var chunk1="chunk-1";console.log(chunk1);\n`);
+  expect(chunk1.map).toBeFalsy();
+  expect(chunk2.code).toBe(`var chunk2 = 'chunk-2';\nconsole.log(chunk2);\n`);
+  expect(chunk2.map).toBeFalsy();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,6 +1341,11 @@ estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -3411,6 +3416,13 @@ rimraf@^2.6.2:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
add option to `include` and `exclude`  chunk files (implement of #54)

```js
uglify({
  include: ['some*', 'foo.js'],
  exclude: /other.*/
})
```