### PR TITLE
Reject sourcemap before sending it to uglify

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,17 +2,24 @@ const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
 const serialize = require("serialize-javascript");
 
+function reject(raw, rejected) {
+  return Object.keys(raw)
+    .filter(key => !rejected.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = raw[key];
+      return obj;
+    }, {});
+}
+
 function uglify(userOptions = {}) {
   if (userOptions.sourceMap != null) {
     throw Error("sourceMap option is removed, use sourcemap instead");
   }
 
   const minifierOptions = serialize(
-    Object.assign({}, userOptions, {
-      sourceMap: userOptions.sourcemap !== false,
-      sourcemap: undefined,
-      numWorkers: undefined
-    })
+    reject(Object.assign({}, userOptions, {
+      sourceMap: userOptions.sourcemap !== false
+    }), [ "sourcemap" ])
   );
 
   return {

--- a/index.js
+++ b/index.js
@@ -2,25 +2,22 @@ const { codeFrameColumns } = require("@babel/code-frame");
 const Worker = require("jest-worker").default;
 const serialize = require("serialize-javascript");
 
-function reject(raw, rejected) {
-  return Object.keys(raw)
-    .filter(key => !rejected.includes(key))
-    .reduce((obj, key) => {
-      obj[key] = raw[key];
-      return obj;
-    }, {});
-}
-
 function uglify(userOptions = {}) {
   if (userOptions.sourceMap != null) {
     throw Error("sourceMap option is removed, use sourcemap instead");
   }
 
-  const minifierOptions = serialize(
-    reject(Object.assign({}, userOptions, {
-      sourceMap: userOptions.sourcemap !== false
-    }), [ "sourcemap" ])
-  );
+  const normalizedOptions = Object.assign({}, userOptions, {
+    sourceMap: userOptions.sourcemap !== false
+  });
+
+  ["sourcemap"].forEach(key => {
+    if (normalizedOptions.hasOwnProperty(key)) {
+      delete normalizedOptions[key];
+    }
+  });
+
+  const minifierOptions = serialize(normalizedOptions);
 
   return {
     name: "uglify",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "jest-worker": "^24.0.0",
-    "serialize-javascript": "^1.6.1",
+    "serialize-javascript": "^1.9.0",
     "uglify-js": "^3.4.9"
   },
   "peerDependencies": {


### PR DESCRIPTION
At some point today, our builds started failing with a sourcemap error
from this lib. Running the tests here makes it replicable:

```
  ● allow to disable source maps

    DefaultsError: `sourcemap` is not a supported option

      at DefaultsError.get (eval at <anonymous> (node_modules/uglify-js/tools/node.js:20:1), <anonymous>:71:23)
```

This fixes the error by rejecting the option uglify is now rejecting before the whole thing crashes. I have no idea what's changed today, as the option rejection has been in uglify for ages: https://github.com/mishoo/UglifyJS2/blob/v3.6.0/lib/utils.js#L93